### PR TITLE
Use always '/' in URL

### DIFF
--- a/src/main/java/org/atteo/cachemanifest/CacheManifestMojo.java
+++ b/src/main/java/org/atteo/cachemanifest/CacheManifestMojo.java
@@ -57,7 +57,10 @@ public class CacheManifestMojo extends AbstractMojo {
 		final Set<String> resourceEntries = new TreeSet<>();
 
 		for (FileSet resource : fileResources) {
-			resourceEntries.addAll(Arrays.asList(fileSetManager.getIncludedFiles(resource)));
+			for(String file : fileSetManager.getIncludedFiles(resource)) {
+				// always use slash as separator char
+				resourceEntries.add(file.replace(File.separatorChar, '/'));
+			}
 		}
 
 		resourceEntries.addAll(resources);


### PR DESCRIPTION
Use always slash as separator char.
This fix a Windows issue.

Please release a merged version.
Thank you.
